### PR TITLE
Removed SiteCode from Parameterlis

### DIFF
--- a/Collections/Get-ConfigMgrCollectionEvalTimes.ps1
+++ b/Collections/Get-ConfigMgrCollectionEvalTimes.ps1
@@ -55,8 +55,6 @@
     Path to one or multiple colleval.log files. Will use SMS_LOG_PATH if nothing has been set.
 .PARAMETER ProviderMachineName
     Name of the SMS Provider. Will use local system if nothing has been set.
-.PARAMETER SiteCode
-    SiteCode of Site
 #>
 param
 (


### PR DESCRIPTION
The SiteCode Info is now queried dynamically. If the Script is not able to obtain any SiteCode info the user gets propted to enter the correct information